### PR TITLE
feat: shape transcript text live before display

### DIFF
--- a/packages/active-listener/src/active_listener/app/service.py
+++ b/packages/active-listener/src/active_listener/app/service.py
@@ -107,7 +107,6 @@ class ActiveListenerService:
       rewrite_client=self.rewrite_client,
       history_store=self.history_store,
       dbus_service=self.dbus_service,
-      ingest_transcription_message=self._recording_session.ingest_transcription_message,
       current_llm_available=self.current_llm_available,
       current_llm_active=self.current_llm_active,
       current_disconnect_generation=self._current_disconnect_generation,

--- a/packages/active-listener/src/active_listener/recording/finalizer.py
+++ b/packages/active-listener/src/active_listener/recording/finalizer.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-import re
-from collections.abc import Awaitable, Callable, Iterable, Mapping
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import cast
 
 from structlog.stdlib import BoundLogger
 
@@ -15,7 +13,6 @@ from active_listener.app.ports import (
   ActiveListenerClient,
   ActiveListenerRewriteClient,
   ActiveListenerTranscriptHistoryStore,
-  CorrectionLoadTask,
   FinalizedTranscriptRecord,
   FinishedRecording,
   RewriteResult,
@@ -28,19 +25,20 @@ from active_listener.config.models import (
 from active_listener.infra.audio import encode_recording_audio
 from active_listener.infra.corrections import (
   ActiveListenerCorrectionStore,
+  CorrectionMap,
   CorrectionStore,
-  apply_corrections,
 )
 from active_listener.infra.dbus import AppStateService
 from active_listener.infra.emitter import TextEmitter
 from active_listener.recording.reducer import (
-  RecordingReducerState,
-  TranscriptionUpdate,
+  apply_segment_reduction,
   build_completed_text_runs,
+  reduce_new_segments,
   render_text,
-  serialize_text_runs,
+  serialize_runs_for_rewrite,
+  serialize_runs_without_commands,
 )
-from eavesdrop.wire import TranscriptionMessage
+from active_listener.recording.text_shaping import shape_runs
 
 from ..infra.langfuse import (
   RecordingObservation,
@@ -50,67 +48,6 @@ from ..infra.langfuse import (
   update_recording_observation,
 )
 
-
-def _empty_metadata() -> dict[str, object]:
-  return {}
-
-
-@dataclass(frozen=True)
-class PipelineContext:
-  transcript: str
-  llm_enabled: bool
-  metadata: Mapping[str, object] = field(default_factory=_empty_metadata)
-
-
-PipelineStep = Callable[[PipelineContext], Awaitable[PipelineContext]]
-
-# Spoken symbol words recognized by `_replace_symbols`. DO NOT expand this list
-# casually — it is deliberately tiny so that normal prose words never collide.
-_SYMBOL_WORDS = {
-  "backslash": "\\",
-  "dot": ".",
-  "hashtag": "#",
-  "slash": "/",
-  "tild": "~",
-  "tilde": "~",
-}
-_SYMBOL_PATTERN = re.compile(
-  r"\s*\b(" + "|".join(_SYMBOL_WORDS) + r")\b\s*",
-  re.IGNORECASE,
-)
-
-# Case-insensitive whole-phrase replacements applied BEFORE symbol fusion.
-# Keys are matched case-insensitively; values are substituted verbatim with
-# their canonical casing. Add freely — keep keys lowercase for readability.
-_REPLACEMENTS: dict[str, str] = {
-  "debass": "D-Bus",
-  "hillary": "hilary",
-  "tild": "tilde",
-  "yamel": "yaml",
-}
-_REPLACEMENT_PATTERN = (
-  re.compile(
-    r"\b(" + "|".join(re.escape(k) for k in _REPLACEMENTS) + r")\b",
-    re.IGNORECASE,
-  )
-  if _REPLACEMENTS
-  else None
-)
-_INSTRUCTION_TAG_PATTERN = re.compile(r"</?\s*instruction\s*>", re.IGNORECASE)
-_THANK_YOU_PATTERN = re.compile(r"\b(?:(escape)\s+)?(thank you)\b([,.!?;:]*)", re.IGNORECASE)
-_HORIZONTAL_WHITESPACE_PATTERN = re.compile(r"[ \t]{2,}")
-_REMOVE_PRECEDING_THANK_YOU_INSTRUCTION = (
-  "<instruction>remove the preceding thank you</instruction>"
-)
-_REWRITE_RESULT_METADATA_KEY = "rewrite_result"
-_CORRECTION_LOAD_TASK_METADATA_KEY = "correction_load_task"
-_RECORDING_ID_METADATA_KEY = "recording_id"
-_RECORDING_OBSERVATION_METADATA_KEY = "recording_observation"
-
-RecordingMessageIngestor = Callable[
-  [RecordingReducerState, TranscriptionMessage],
-  TranscriptionUpdate | None,
-]
 LlmAvailabilityReader = Callable[[], bool]
 LlmActiveReader = Callable[[], bool]
 DisconnectGenerationReader = Callable[[], int]
@@ -127,7 +64,6 @@ class RecordingFinalizer:
   rewrite_client: ActiveListenerRewriteClient
   history_store: ActiveListenerTranscriptHistoryStore
   dbus_service: AppStateService
-  ingest_transcription_message: RecordingMessageIngestor
   current_llm_available: LlmAvailabilityReader
   current_llm_active: LlmActiveReader
   current_disconnect_generation: DisconnectGenerationReader
@@ -198,16 +134,31 @@ class RecordingFinalizer:
           )
           self.logger.warning("skipping emission after disconnect", stream=message.stream)
           return
-
-        _ = self.ingest_transcription_message(reducer_state, message)
-        completed_runs = build_completed_text_runs(reducer_state)
+        # Resolve stored corrections locally. The session clears its own load task during
+        # teardown and a new recording may already own the live session, so the finalizer
+        # never reads or writes live-session state: it shapes this recording's committed text
+        # from the reducer state and correction task carried on the finished recording.
+        corrections = await self._resolve_corrections(finished_recording, stream=message.stream)
+        # Reduce the final flushed window into this recording's private reducer state.
+        reduction = reduce_new_segments(message.segments, reducer_state.last_id)
+        apply_segment_reduction(reducer_state, reduction)
+        reducer_state.last_id = reduction.last_id
+        # raw_text is the unshaped "before" snapshot, retained only for history/observation.
         raw_text = render_text(reducer_state.completed_words)
         if not raw_text:
           self.logger.info("recording finalized without committed text", stream=message.stream)
           return
 
         self.logger.info("finalized raw transcript", stream=message.stream, raw_text=raw_text)
-        rewrite_input = serialize_text_runs(completed_runs)
+        completed_runs = shape_runs(build_completed_text_runs(reducer_state), corrections)
+        # LLM-input view: command runs are wrapped in instruction markers. Marker-wrapping is
+        # an LLM-boundary concern, so the shaping pipeline never needs to know the LLM exists.
+        rewrite_input = serialize_runs_for_rewrite(completed_runs)
+        # Shaping can empty the committed text (e.g. a dictation that was only a hallucinated
+        # "thank you"); skip the rewrite rather than calling the LLM on empty input.
+        if not rewrite_input.strip():
+          self.logger.info("recording finalized without committed text", stream=message.stream)
+          return
         if recording_observation is not None:
           _ = recording_observation.update(
             input={
@@ -223,31 +174,35 @@ class RecordingFinalizer:
             },
           )
 
-        pipeline_steps = self._pipeline_steps(stream=message.stream)
-        pipeline_context = await self._run_pipeline(
-          context=PipelineContext(
-            transcript=rewrite_input,
-            llm_enabled=self.current_llm_active(),
-            metadata={
-              _CORRECTION_LOAD_TASK_METADATA_KEY: finished_recording.correction_load_task,
-              _RECORDING_ID_METADATA_KEY: finished_recording.recording_id,
-              _RECORDING_OBSERVATION_METADATA_KEY: recording_observation,
-            },
-          ),
-          steps=pipeline_steps,
-          stream=message.stream,
-        )
-        if pipeline_context is None:
-          update_recording_observation(
-            recording_observation,
-            logger=self.logger,
-            level="ERROR",
-            status_message="finalization pipeline failed",
-          )
+        rewrite_result: RewriteResult | None = None
+        if self.current_llm_active():
+          try:
+            rewrite_result = await self._rewrite_with_llm(
+              transcript=rewrite_input,
+              stream=message.stream,
+              recording_id=finished_recording.recording_id,
+              recording_observation=recording_observation,
+            )
+          except Exception as exc:
+            self.logger.exception(
+              "dictation pipeline step failed",
+              stream=message.stream,
+              step="rewrite_with_llm",
+              reason=str(exc),
+            )
+            await self.dbus_service.pipeline_failed("rewrite_with_llm", str(exc))
+            return
+          final_text = rewrite_result.text
+        else:
+          # No LLM to consume the dictated command instructions, so each command run is
+          # dropped entirely rather than pasted literally into the editor. This path is pure
+          # and cannot fail, so it carries no failure signal.
+          final_text = serialize_runs_without_commands(completed_runs)
+        if not final_text.strip():
+          self.logger.info("recording finalized without committed text", stream=message.stream)
           return
-
-        final_text = pipeline_context.transcript
-        rewrite_result = _rewrite_result_from_metadata(pipeline_context.metadata)
+        # Trailing space (formerly the append_trailing_space pipeline step).
+        final_text = f"{final_text} "
 
         llm_mode = _llm_mode(
           llm_available=self.current_llm_available(),
@@ -321,148 +276,49 @@ class RecordingFinalizer:
     finally:
       end_recording_observation(recording_observation, logger=self.logger)
 
-  def _pipeline_steps(self, *, stream: str) -> list[PipelineStep]:
-    async def rewrite_with_llm(context: PipelineContext) -> PipelineContext:
-      return await self._rewrite_with_llm(context=context, stream=stream)
+  async def _resolve_corrections(
+    self, finished_recording: FinishedRecording, *, stream: str
+  ) -> CorrectionMap:
+    """Await this recording's stored-correction load and return the map.
 
-    async def apply_stored_corrections(context: PipelineContext) -> PipelineContext:
-      return await self._apply_stored_corrections(context=context, stream=stream)
+    The session drops its own correction load task during teardown, so the surviving task
+    travels on the finished recording. Resolving it here keeps the finalizer independent of
+    live-session state, which a subsequent recording may already own.
 
-    async def append_trailing_space(context: PipelineContext) -> PipelineContext:
-      return _update_pipeline_context(
-        context,
-        transcript=f"{context.transcript} ",
-      )
-
-    steps: list[PipelineStep] = [
-      self._strip_instruction_tags_when_llm_disabled,
-      self._apply_replacements,
-      self._apply_thank_you_escape,
-      self._replace_symbols,
-      apply_stored_corrections,
-      rewrite_with_llm,
-      append_trailing_space,
-    ]
-
-    return steps
-
-  async def _strip_instruction_tags_when_llm_disabled(
-    self,
-    context: PipelineContext,
-  ) -> PipelineContext:
-    if context.llm_enabled:
-      return context
-
-    return _update_pipeline_context(
-      context,
-      transcript=_strip_instruction_tags(context.transcript),
-    )
-
-  async def _apply_replacements(self, context: PipelineContext) -> PipelineContext:
-    # Case-insensitive whole-word/phrase substitution driven by `_REPLACEMENTS`.
-    # Extend the map at module level; this function should stay dumb.
-    if _REPLACEMENT_PATTERN is None:
-      return context
-    replacement_pattern = _REPLACEMENT_PATTERN
-    return _update_pipeline_context(
-      context,
-      transcript=replacement_pattern.sub(
-        lambda m: _REPLACEMENTS[m.group(1).lower()],
-        context.transcript,
-      ),
-    )
-
-  async def _replace_symbols(self, context: PipelineContext) -> PipelineContext:
-    #! This satisfies the design intent. Do not touch.
-    #
-    # Fuse spoken symbol words into their glyphs, swallowing adjacent whitespace:
-    # e.g. "tild slash dot omp slash agent slash skills" -> "~/.omp/agent/skills".
-    symbol_pattern = _SYMBOL_PATTERN
-    return _update_pipeline_context(
-      context,
-      transcript=symbol_pattern.sub(
-        lambda m: _SYMBOL_WORDS[m.group(1).lower()],
-        context.transcript,
-      ),
-    )
-
-  async def _apply_thank_you_escape(self, context: PipelineContext) -> PipelineContext:
-    return _update_pipeline_context(
-      context,
-      transcript=_apply_thank_you_policy(
-        context.transcript,
-        llm_enabled=context.llm_enabled,
-      ),
-    )
-
-  async def _apply_stored_corrections(
-    self,
-    *,
-    context: PipelineContext,
-    stream: str,
-  ) -> PipelineContext:
-    correction_load_task = _correction_load_task_from_metadata(context.metadata)
-    if correction_load_task is None:
-      return context
-
+    :param finished_recording: The recording being finalized.
+    :type finished_recording: FinishedRecording
+    :param stream: Stream identifier for logging.
+    :type stream: str
+    :returns: Loaded spelling corrections, or an empty map on failure or absence.
+    :rtype: CorrectionMap
+    """
+    task = finished_recording.correction_load_task
+    if task is None:
+      return {}
     try:
-      corrections = await correction_load_task
+      return await task
     except Exception:
       self.logger.exception("stored correction load failed", stream=stream)
-      return context
-
-    corrected_transcript = apply_corrections(context.transcript, corrections)
-    if corrected_transcript != context.transcript:
-      self.logger.info(
-        "stored corrections applied",
-        stream=stream,
-        correction_count=len(corrections),
-      )
-    return _update_pipeline_context(context, transcript=corrected_transcript)
-
-  async def _run_pipeline(
-    self,
-    *,
-    context: PipelineContext,
-    steps: Iterable[PipelineStep],
-    stream: str,
-  ) -> PipelineContext | None:
-    for step in steps:
-      try:
-        context = await step(context)
-      except Exception as exc:
-        self.logger.exception(
-          "dictation pipeline step failed",
-          stream=stream,
-          step=step.__name__,
-          reason=str(exc),
-        )
-        await self.dbus_service.pipeline_failed(step.__name__, str(exc))
-        return None
-
-    return context
+      return {}
 
   async def _rewrite_with_llm(
     self,
     *,
-    context: PipelineContext,
+    transcript: str,
     stream: str,
-  ) -> PipelineContext:
-    if not context.llm_enabled:
-      return context
-
+    recording_id: str,
+    recording_observation: RecordingObservation | None,
+  ) -> RewriteResult:
     rewrite_config = self.config.llm_rewrite
+    # Defensive: unreachable while current_llm_active() gates the call site.
     if rewrite_config is None:
       raise rewrite_module.RewriteClientError("rewrite is disabled")
-
-    prompt_path: str | None = None
 
     #! This very deliberately happens on each recording run. DO NOT ALTER THIS. Do not ask
     # about loading up front. Just leave it.
     loaded_prompt = rewrite_module.load_active_listener_rewrite_prompt(rewrite_config.prompt_path)
     prompt = loaded_prompt.prompt
     prompt_path = str(loaded_prompt.prompt_path)
-    rewrite_input = context.transcript
     self.logger.info(
       "rewrite prompt loaded",
       stream=stream,
@@ -472,25 +328,25 @@ class RecordingFinalizer:
       "rewrite started",
       stream=stream,
       prompt_path=prompt_path,
-      rewrite_input=rewrite_input,
+      rewrite_input=transcript,
     )
     provider = _rewrite_provider_type(rewrite_config)
     model = _rewrite_model(rewrite_config)
 
     with start_rewrite_observation(
       session_id=stream,
-      recording_id=_recording_id_from_metadata(context.metadata),
+      recording_id=recording_id,
       provider=provider,
       model=model,
       prompt_path=prompt_path,
       stream=stream,
-      transcript=rewrite_input,
-      parent_observation=_recording_observation_from_metadata(context.metadata),
+      transcript=transcript,
+      parent_observation=recording_observation,
     ) as observation:
       try:
         rewrite_result = await self.rewrite_client.rewrite_text(
           instructions=prompt.instructions,
-          transcript=rewrite_input,
+          transcript=transcript,
         )
       except Exception as exc:
         if observation is not None:
@@ -508,7 +364,7 @@ class RecordingFinalizer:
       "rewrite succeeded",
       stream=stream,
       prompt_path=prompt_path,
-      rewrite_input=rewrite_input,
+      rewrite_input=transcript,
       rewritten_text=rewrite_result.text,
     )
     if rewrite_result.corrections:
@@ -527,90 +383,11 @@ class RecordingFinalizer:
           correction_count=len(rewrite_result.corrections),
           path=str(self.correction_store.path),
         )
-    return _update_pipeline_context(
-      context,
-      transcript=rewrite_result.text,
-      metadata_updates={_REWRITE_RESULT_METADATA_KEY: rewrite_result},
-    )
+    return rewrite_result
 
 
 def _count_words(text: str) -> int:
   return len(text.split())
-
-
-def _update_pipeline_context(
-  context: PipelineContext,
-  *,
-  transcript: str,
-  metadata_updates: Mapping[str, object] | None = None,
-) -> PipelineContext:
-  metadata = (
-    context.metadata if metadata_updates is None else {**context.metadata, **metadata_updates}
-  )
-  return PipelineContext(
-    transcript=transcript,
-    llm_enabled=context.llm_enabled,
-    metadata=metadata,
-  )
-
-
-def _rewrite_result_from_metadata(metadata: Mapping[str, object]) -> RewriteResult | None:
-  rewrite_result = metadata.get(_REWRITE_RESULT_METADATA_KEY)
-  if rewrite_result is None:
-    return None
-
-  if not isinstance(rewrite_result, RewriteResult):
-    raise TypeError("rewrite_result metadata must be a RewriteResult")
-
-  return rewrite_result
-
-
-def _correction_load_task_from_metadata(
-  metadata: Mapping[str, object],
-) -> CorrectionLoadTask | None:
-  correction_load_task = metadata.get(_CORRECTION_LOAD_TASK_METADATA_KEY)
-  if correction_load_task is None:
-    return None
-
-  if not isinstance(correction_load_task, asyncio.Task):
-    raise TypeError("correction_load_task metadata must be an asyncio.Task")
-
-  return cast(CorrectionLoadTask, correction_load_task)
-
-
-def _recording_observation_from_metadata(
-  metadata: Mapping[str, object],
-) -> RecordingObservation | None:
-  recording_observation = metadata.get(_RECORDING_OBSERVATION_METADATA_KEY)
-  if recording_observation is None:
-    return None
-
-  return cast(RecordingObservation, recording_observation)
-
-
-def _recording_id_from_metadata(metadata: Mapping[str, object]) -> str:
-  return cast(str, metadata[_RECORDING_ID_METADATA_KEY])
-
-
-def _strip_instruction_tags(text: str) -> str:
-  return _INSTRUCTION_TAG_PATTERN.sub("", text)
-
-
-def _apply_thank_you_policy(text: str, *, llm_enabled: bool) -> str:
-  def replace_match(match: re.Match[str]) -> str:
-    thank_you_text = f"{match.group(2)}{match.group(3)}"
-    if match.group(1) is not None:
-      return thank_you_text
-
-    if not llm_enabled:
-      return ""
-
-    return f"{thank_you_text} {_REMOVE_PRECEDING_THANK_YOU_INSTRUCTION}"
-
-  return _HORIZONTAL_WHITESPACE_PATTERN.sub(
-    " ",
-    _THANK_YOU_PATTERN.sub(replace_match, text),
-  ).strip()
 
 
 def _llm_mode(*, llm_available: bool, rewrite_ran: bool) -> str:

--- a/packages/active-listener/src/active_listener/recording/reducer.py
+++ b/packages/active-listener/src/active_listener/recording/reducer.py
@@ -175,22 +175,6 @@ def reduce_new_segments(
   )
 
 
-def build_transcription_update(state: RecordingReducerState) -> TranscriptionUpdate | None:
-  """Build a normalized transcript snapshot for live UI consumers.
-
-  :param state: Recording reducer state after the latest reduction was applied.
-  :type state: RecordingReducerState
-  :returns: Ordered normalized transcript snapshot, or ``None`` when no text is present.
-  :rtype: TranscriptionUpdate | None
-  """
-
-  runs = build_text_runs(state)
-  if not runs:
-    return None
-
-  return TranscriptionUpdate(runs=runs)
-
-
 def apply_segment_reduction(state: RecordingReducerState, reduction: SegmentReduction) -> None:
   """Apply a reduced transcription window to the recording state.
 
@@ -396,6 +380,18 @@ def build_completed_text_runs(state: RecordingReducerState) -> list[TextRun]:
   return normalize_runs(group_words(classify_words(state.completed_words, state)))
 
 
+def build_incomplete_text_runs(state: RecordingReducerState) -> list[TextRun]:
+  """Build normalized transcript runs for the incomplete (unstable) tail only.
+
+  :param state: Recording reducer state to render.
+  :type state: RecordingReducerState
+  :returns: Ordered normalized transcript runs for the in-progress tail.
+  :rtype: list[TextRun]
+  """
+
+  return normalize_runs(group_words(classify_words(state.incomplete_words, state)))
+
+
 def segment_words(segment: Segment, *, is_complete: bool) -> list[TimedWord]:
   """Convert one segment into ordered transcript words.
 
@@ -445,8 +441,8 @@ def render_text(words: Sequence[TimedWord]) -> str:
   return " ".join(word.text for word in words)
 
 
-def serialize_text_runs(runs: Sequence[TextRun]) -> str:
-  """Serialize normalized transcript runs for rewrite input.
+def serialize_runs_for_rewrite(runs: Sequence[TextRun]) -> str:
+  """Serialize runs as LLM rewrite input; command runs are wrapped in instruction markers.
 
   :param runs: Ordered normalized transcript runs.
   :type runs: Sequence[TextRun]
@@ -462,6 +458,21 @@ def serialize_text_runs(runs: Sequence[TextRun]) -> str:
     serialized_parts.append(run.text)
 
   return " ".join(serialized_parts)
+
+
+def serialize_runs_without_commands(runs: Sequence[TextRun]) -> str:
+  """Serialize runs for the LLM-off path; command runs are dropped entirely.
+
+  A command run is an instruction with no consumer when the LLM is disabled, so its
+  content is removed rather than pasted literally.
+
+  :param runs: Ordered normalized transcript runs.
+  :type runs: Sequence[TextRun]
+  :returns: Flat output string with command runs removed.
+  :rtype: str
+  """
+
+  return " ".join(run.text for run in normalize_runs(runs) if not run.is_command)
 
 
 def _require_word_timestamps(segments: Sequence[Segment]) -> None:

--- a/packages/active-listener/src/active_listener/recording/session.py
+++ b/packages/active-listener/src/active_listener/recording/session.py
@@ -16,6 +16,7 @@ from active_listener.app.ports import (
   CorrectionLoadTask,
   FinishedRecording,
 )
+from active_listener.infra.corrections import CorrectionMap
 from active_listener.infra.keyboard import KeyboardInput, RecordingGrabRelease
 from active_listener.recording.reducer import (
   RecordingReducerState,
@@ -24,14 +25,20 @@ from active_listener.recording.reducer import (
   TimeSpan,
   TranscriptionUpdate,
   apply_segment_reduction,
-  build_transcription_update,
+  build_completed_text_runs,
+  build_incomplete_text_runs,
   reduce_new_segments,
 )
 from active_listener.recording.spectrum import SAMPLE_RATE_HZ
+from active_listener.recording.text_shaping import shape_runs
 from eavesdrop.wire import Segment, TranscriptionMessage
 
 HOLD_THRESHOLD_S = 0.250
 RECORDING_CHANNEL_COUNT = 1
+
+
+def _empty_corrections() -> dict[str, str]:
+  return {}
 
 
 @dataclass
@@ -83,6 +90,13 @@ class RecordingSession:
   _correction_load_task: CorrectionLoadTask | None = None
   _pending_caps_gesture: PendingCapsGesture | None = None
   _last_transcription_runs: list[TextRun] = field(default_factory=list)
+  _loaded_corrections: CorrectionMap = field(default_factory=_empty_corrections)
+  _corrections_harvested: bool = False
+  # Overlay cache: shaped completed runs plus the raw runs they were shaped from. Completed
+  # text is byte-stable once committed, so we reshape only when the raw committed runs change
+  # (or corrections load), not on every window that merely revises the incomplete tail.
+  _shaped_completed_runs: list[TextRun] = field(default_factory=list)
+  _shaped_completed_source: list[TextRun] = field(default_factory=list)
 
   @property
   def is_recording(self) -> bool:
@@ -123,6 +137,10 @@ class RecordingSession:
     self._recording_reducer_state = RecordingReducerState()
     self.audio_buffer.start()
     self._last_transcription_runs = []
+    self._loaded_corrections = {}
+    self._corrections_harvested = False
+    self._shaped_completed_runs = []
+    self._shaped_completed_source = []
     self._connection_last_id = None
     self.logger.debug(
       "recording session started",
@@ -265,7 +283,19 @@ class RecordingSession:
       )
     state.last_id = reduction.last_id
     self._connection_last_id = reduction.last_id
-    transcription_update = build_transcription_update(state)
+    # Shaping runs live (not just at finalize) so the overlay preview equals the LLM input
+    # for committed text. Only completed runs are shaped: the incomplete tail is unstable
+    # (Whisper keeps revising it), so shaping it would flicker the preview — a transient
+    # "thank you" vanishing then reappearing, "dot"/"slash" fusing prematurely. The LLM only
+    # ever consumes completed runs, so the tail never needs shaping. Reshape only when the
+    # committed runs actually change; most windows just churn the tail and reuse the cache.
+    self._harvest_corrections()
+    completed_source = build_completed_text_runs(state)
+    if completed_source != self._shaped_completed_source:
+      self._shaped_completed_source = completed_source
+      self._shaped_completed_runs = shape_runs(completed_source, self._loaded_corrections)
+    overlay_runs = [*self._shaped_completed_runs, *build_incomplete_text_runs(state)]
+    transcription_update = TranscriptionUpdate(runs=overlay_runs) if overlay_runs else None
     if (
       transcription_update is not None
       and transcription_update.runs == self._last_transcription_runs
@@ -291,6 +321,22 @@ class RecordingSession:
       overlay_update=transcription_update is not None,
     )
     return transcription_update
+
+  def _harvest_corrections(self) -> None:
+    # Non-blocking live path: adopt stored corrections as soon as the load task settles,
+    # so live windows shape with corrections without ever stalling on the load.
+    task = self._correction_load_task
+    if task is None or self._corrections_harvested or not task.done():
+      return
+    self._corrections_harvested = True
+    try:
+      self._loaded_corrections = task.result()
+    except Exception:
+      self.logger.exception("stored correction load failed")
+      self._loaded_corrections = {}
+    # Corrections changed: invalidate the shaped cache so the next window reshapes committed
+    # runs with them. The reshape happens later in this same ingest, so no window goes stale.
+    self._shaped_completed_source = []
 
   async def _exit_recording(
     self,
@@ -327,6 +373,10 @@ class RecordingSession:
     correction_load_task = self._correction_load_task
     self._correction_load_task = None
     self._last_transcription_runs = []
+    self._loaded_corrections = {}
+    self._corrections_harvested = False
+    self._shaped_completed_runs = []
+    self._shaped_completed_source = []
 
     if cancel_correction_load and correction_load_task is not None:
       if not correction_load_task.done():

--- a/packages/active-listener/src/active_listener/recording/text_shaping.py
+++ b/packages/active-listener/src/active_listener/recording/text_shaping.py
@@ -1,0 +1,112 @@
+"""Deterministic text shaping for active-listener transcript runs.
+
+These transforms used to live only inside the finalizer, so the live overlay
+showed raw, un-shaped transcript while speaking. They now run on every
+transcription window (feeding the live preview) and once more on the final
+flushed window, so what the user sees while speaking is exactly the content
+that gets serialized for the LLM. Shaping is intentionally ignorant of the LLM:
+instruction markers and command-dropping are applied at the LLM boundary, not
+here (see ``recording/reducer.py`` serializers).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import replace
+
+from active_listener.infra.corrections import CorrectionMap, apply_corrections
+from active_listener.recording.reducer import TextRun, normalize_runs
+
+# Spoken symbol words recognized by `_replace_symbols`. DO NOT expand this list
+# casually — it is deliberately tiny so that normal prose words never collide.
+_SYMBOL_WORDS = {
+  "backslash": "\\",
+  "dot": ".",
+  "hashtag": "#",
+  "slash": "/",
+  "tild": "~",
+  "tilde": "~",
+}
+_SYMBOL_PATTERN = re.compile(
+  r"\s*\b(" + "|".join(_SYMBOL_WORDS) + r")\b\s*",
+  re.IGNORECASE,
+)
+
+# Case-insensitive whole-phrase replacements applied BEFORE symbol fusion.
+# Keys are matched case-insensitively; values are substituted verbatim with
+# their canonical casing. Add freely — keep keys lowercase for readability.
+_REPLACEMENTS: dict[str, str] = {
+  "debass": "D-Bus",
+  "hillary": "hilary",
+  "tild": "tilde",
+  "yamel": "yaml",
+}
+_REPLACEMENT_PATTERN = (
+  re.compile(
+    r"\b(" + "|".join(re.escape(k) for k in _REPLACEMENTS) + r")\b",
+    re.IGNORECASE,
+  )
+  if _REPLACEMENTS
+  else None
+)
+_THANK_YOU_PATTERN = re.compile(r"\b(?:(escape)\s+)?(thank you)\b([,.!?;:]*)", re.IGNORECASE)
+_HORIZONTAL_WHITESPACE_PATTERN = re.compile(r"[ \t]{2,}")
+
+
+def shape_runs(runs: Sequence[TextRun], corrections: CorrectionMap) -> list[TextRun]:
+  """Apply deterministic text shaping to every run, per run.
+
+  Transforms apply within a single run, so a symbol phrase or thank-you split
+  across a command/normal boundary will not fuse — accepted, those splits do
+  not occur in practice. ``normalize_runs`` re-application is required because
+  thank-you removal can empty a run; ``normalize_runs`` drops empties and
+  re-merges adjacent same-flag runs.
+
+  :param runs: Transcript runs to shape.
+  :param corrections: Stored corrections applied after the built-in transforms.
+  :returns: Shaped, normalized runs.
+  """
+  return normalize_runs([replace(run, text=_shape_text(run.text, corrections)) for run in runs])
+
+
+def _shape_text(text: str, corrections: CorrectionMap) -> str:
+  text = _apply_replacements(text)  # replacements BEFORE symbol fusion (existing order)
+  text = _apply_thank_you(text)
+  text = _replace_symbols(text)
+  text = apply_corrections(text, corrections)
+  return text
+
+
+def _apply_replacements(text: str) -> str:
+  # Case-insensitive whole-word/phrase substitution driven by `_REPLACEMENTS`.
+  # Extend the map at module level; this function should stay dumb.
+  if _REPLACEMENT_PATTERN is None:
+    return text
+  return _REPLACEMENT_PATTERN.sub(lambda m: _REPLACEMENTS[m.group(1).lower()], text)
+
+
+def _replace_symbols(text: str) -> str:
+  #! This satisfies the design intent. Do not touch.
+  #
+  # Fuse spoken symbol words into their glyphs, swallowing adjacent whitespace:
+  # e.g. "tild slash dot omp slash agent slash skills" -> "~/.omp/agent/skills".
+  return _SYMBOL_PATTERN.sub(lambda m: _SYMBOL_WORDS[m.group(1).lower()], text)
+
+
+def _apply_thank_you(text: str) -> str:
+  # Whisper hallucinates "thank you" at utterance/silence boundaries; it is a
+  # model artifact, not user speech, so it is always removed before display and
+  # before the LLM. "escape thank you" is the deliberate opt-out: the escape
+  # word is consumed and the literal "thank you" is preserved.
+  def replace_match(match: re.Match[str]) -> str:
+    thank_you_text = f"{match.group(2)}{match.group(3)}"
+    if match.group(1) is not None:
+      return thank_you_text
+
+    return ""
+
+  return _HORIZONTAL_WHITESPACE_PATTERN.sub(
+    " ",
+    _THANK_YOU_PATTERN.sub(replace_match, text),
+  ).strip()

--- a/packages/active-listener/tests/test_app.py
+++ b/packages/active-listener/tests/test_app.py
@@ -2665,7 +2665,7 @@ async def test_finalize_recording_keeps_escaped_thank_you_mentions() -> None:
 
 
 @pytest.mark.asyncio
-async def test_finalize_recording_strips_instruction_tags_when_llm_is_disabled() -> None:
+async def test_finalize_recording_drops_command_runs_when_llm_is_disabled() -> None:
   client = FakeClient(
     flush_results=[
       _message(
@@ -2716,12 +2716,12 @@ async def test_finalize_recording_strips_instruction_tags_when_llm_is_disabled()
   _ = await harness.service.handle_action(AppAction.START_OR_FINISH)
   await harness.service.wait_for_background_tasks()
 
-  assert harness.emitter.emitted == ["Hello, scratch that. Bye. "]
+  assert harness.emitter.emitted == ["Hello, Bye. "]
   assert harness.rewrite_client.calls == []
 
 
 @pytest.mark.asyncio
-async def test_finalize_recording_injects_thank_you_instruction_when_llm_enabled(
+async def test_finalize_recording_removes_thank_you_before_rewrite_when_llm_enabled(
   monkeypatch: pytest.MonkeyPatch,
 ) -> None:
   client = FakeClient(
@@ -2755,12 +2755,117 @@ async def test_finalize_recording_injects_thank_you_instruction_when_llm_enabled
   assert rewrite_client.calls == [
     {
       "instructions": "Rewrite this transcript.",
-      "transcript": (
-        "Thank you? <instruction>remove the preceding thank you</instruction> "
-        "thank you, <instruction>remove the preceding thank you</instruction> "
-        "I want to keep going thank you."
-      ),
+      "transcript": "I want to keep going thank you.",
     }
+  ]
+
+
+@pytest.mark.asyncio
+async def test_live_transcription_publishes_shaped_runs() -> None:
+  harness = _service()
+  service = harness.service
+
+  _ = await service.handle_action(AppAction.START_OR_FINISH)
+  reducer_state = _recording_reducer_state(_recording_session(service))
+  assert reducer_state is not None
+  reducer_state.closed_command_spans = [TimeSpan(start_s=0.6, end_s=0.9)]
+
+  await service.handle_client_event(
+    _transcription_event(
+      _live_message(
+        service,
+        _segment(
+          1,
+          "hillary release hashtag 42 thank you",
+          completed=True,
+          start=0.0,
+          end=0.5,
+          words=[
+            _word("hillary", start=0.0, end=0.1),
+            _word("release", start=0.1, end=0.2),
+            _word("hashtag", start=0.2, end=0.3),
+            _word("42", start=0.3, end=0.4),
+            _word("thank", start=0.4, end=0.45),
+            _word("you", start=0.45, end=0.5),
+          ],
+        ),
+        _segment(
+          2,
+          "scratch that.",
+          completed=True,
+          start=0.6,
+          end=0.9,
+          words=[
+            _word("scratch", start=0.6, end=0.75),
+            _word("that.", start=0.75, end=0.9),
+          ],
+        ),
+        flush_complete=False,
+      )
+    )
+  )
+  _ = await service.handle_action(AppAction.CANCEL)
+  await service.wait_for_background_tasks()
+
+  published = [
+    runs for name, runs in harness.dbus_service.signals if name == "TranscriptionUpdated"
+  ]
+  assert published == [
+    [
+      TextRun(text="hilary release#42", is_command=False, is_complete=True),
+      TextRun(text="scratch that.", is_command=True, is_complete=False),
+    ]
+  ]
+
+
+@pytest.mark.asyncio
+async def test_live_overlay_leaves_incomplete_tail_unshaped() -> None:
+  # Flicker guard: the incomplete tail is unstable (Whisper keeps revising it), so it is shown
+  # raw. Shaping it would make the preview flicker — here a transient "thank you" would vanish
+  # then reappear as the segment is revised. Only the committed prefix is shaped.
+  harness = _service()
+  service = harness.service
+
+  _ = await service.handle_action(AppAction.START_OR_FINISH)
+
+  await service.handle_client_event(
+    _transcription_event(
+      _live_message(
+        service,
+        _segment(
+          1,
+          "hillary",
+          completed=True,
+          start=0.0,
+          end=0.2,
+          words=[_word("hillary", start=0.0, end=0.2)],
+        ),
+        _segment(
+          2,
+          "thank you",
+          completed=True,
+          start=0.3,
+          end=0.5,
+          words=[
+            _word("thank", start=0.3, end=0.4),
+            _word("you", start=0.4, end=0.5),
+          ],
+        ),
+        flush_complete=False,
+      )
+    )
+  )
+  _ = await service.handle_action(AppAction.CANCEL)
+  await service.wait_for_background_tasks()
+
+  published = [
+    runs for name, runs in harness.dbus_service.signals if name == "TranscriptionUpdated"
+  ]
+  assert published == [
+    [
+      TextRun(text="hilary", is_command=False, is_complete=True),
+      TextRun(text="thank you", is_command=False, is_complete=False),
+    ]
   ]
 
 

--- a/packages/active-listener/tests/test_reducer.py
+++ b/packages/active-listener/tests/test_reducer.py
@@ -11,12 +11,14 @@ from active_listener.recording.reducer import (
   TimedWord,
   TimeSpan,
   apply_segment_reduction,
-  build_transcription_update,
+  build_completed_text_runs,
+  build_incomplete_text_runs,
   classify_recording_words,
   normalize_runs,
   reduce_new_segments,
   render_text,
-  serialize_text_runs,
+  serialize_runs_for_rewrite,
+  serialize_runs_without_commands,
 )
 from eavesdrop.wire import Segment, Word
 
@@ -135,7 +137,12 @@ def test_apply_segment_reduction_skips_duplicate_segments_after_missing_sentinel
   assert [word.text for word in state.incomplete_words] == ["tail"]
 
 
-def test_build_transcription_update_returns_normalized_runs() -> None:
+def _overlay_runs(state: RecordingReducerState) -> list[TextRun]:
+  """Combine shaped-source completed and incomplete runs the way the overlay does."""
+  return [*build_completed_text_runs(state), *build_incomplete_text_runs(state)]
+
+
+def test_overlay_runs_returns_normalized_runs() -> None:
   reduction = reduce_new_segments(
     [_segment(11, "alpha"), _segment(12, "tail")],
     last_id=None,
@@ -145,10 +152,7 @@ def test_build_transcription_update_returns_normalized_runs() -> None:
   )
   apply_segment_reduction(state, reduction)
 
-  transcription_update = build_transcription_update(state)
-
-  assert transcription_update is not None
-  assert transcription_update.runs == [
+  assert _overlay_runs(state) == [
     TextRun(text="earlier alpha", is_command=False, is_complete=True),
     TextRun(text="tail", is_command=False, is_complete=False),
   ]
@@ -249,7 +253,7 @@ def test_normalize_runs_drops_empty_runs_and_merges_identical_flags() -> None:
   ]
 
 
-def test_build_transcription_update_accumulates_completed_prefix_once_and_replaces_tail() -> None:
+def test_overlay_runs_accumulates_completed_prefix_once_and_replaces_tail() -> None:
   state = RecordingReducerState(last_id=None)
 
   first_reduction = reduce_new_segments(
@@ -269,7 +273,7 @@ def test_build_transcription_update_accumulates_completed_prefix_once_and_replac
   )
   apply_segment_reduction(state, first_reduction)
   state.last_id = first_reduction.last_id
-  first_update = build_transcription_update(state)
+  first_runs = _overlay_runs(state)
 
   second_reduction = reduce_new_segments(
     [
@@ -288,7 +292,7 @@ def test_build_transcription_update_accumulates_completed_prefix_once_and_replac
   )
   apply_segment_reduction(state, second_reduction)
   state.last_id = second_reduction.last_id
-  second_update = build_transcription_update(state)
+  second_runs = _overlay_runs(state)
 
   third_reduction = reduce_new_segments(
     [
@@ -312,26 +316,23 @@ def test_build_transcription_update_accumulates_completed_prefix_once_and_replac
   )
   apply_segment_reduction(state, third_reduction)
   state.last_id = third_reduction.last_id
-  third_update = build_transcription_update(state)
+  third_runs = _overlay_runs(state)
 
-  assert first_update is not None
-  assert first_update.runs == [
+  assert first_runs == [
     TextRun(text="hello", is_command=False, is_complete=True),
     TextRun(text="worl", is_command=False, is_complete=False),
   ]
-  assert second_update is not None
-  assert second_update.runs == [
+  assert second_runs == [
     TextRun(text="hello", is_command=False, is_complete=True),
     TextRun(text="world", is_command=False, is_complete=False),
   ]
-  assert third_update is not None
-  assert third_update.runs == [
+  assert third_runs == [
     TextRun(text="hello world", is_command=False, is_complete=True),
     TextRun(text="again", is_command=False, is_complete=False),
   ]
 
 
-def test_build_transcription_update_recolors_tail_without_reemitting_completed_text() -> None:
+def test_overlay_runs_recolors_tail_without_reemitting_completed_text() -> None:
   state = RecordingReducerState(
     completed_words=[TimedWord(text="hello", start_s=0.0, end_s=0.2, is_complete=True)],
     last_id=1,
@@ -356,7 +357,7 @@ def test_build_transcription_update_recolors_tail_without_reemitting_completed_t
     last_id=state.last_id,
   )
   apply_segment_reduction(state, first_reduction)
-  first_update = build_transcription_update(state)
+  first_runs = _overlay_runs(state)
 
   state.open_command_start_s = 0.5
   second_reduction = reduce_new_segments(
@@ -378,21 +379,19 @@ def test_build_transcription_update_recolors_tail_without_reemitting_completed_t
     last_id=state.last_id,
   )
   apply_segment_reduction(state, second_reduction)
-  second_update = build_transcription_update(state)
+  second_runs = _overlay_runs(state)
 
-  assert first_update is not None
-  assert first_update.runs == [
+  assert first_runs == [
     TextRun(text="hello", is_command=False, is_complete=True),
     TextRun(text="draft command", is_command=False, is_complete=False),
   ]
-  assert second_update is not None
-  assert second_update.runs == [
+  assert second_runs == [
     TextRun(text="hello", is_command=False, is_complete=True),
     TextRun(text="draft command", is_command=True, is_complete=False),
   ]
 
 
-def test_build_transcription_update_reclassifies_completed_words_after_hold_commit() -> None:
+def test_overlay_runs_reclassifies_completed_words_after_hold_commit() -> None:
   state = RecordingReducerState(
     completed_words=[
       TimedWord(text="alpha", start_s=0.6, end_s=0.8, is_complete=True),
@@ -402,26 +401,24 @@ def test_build_transcription_update_reclassifies_completed_words_after_hold_comm
     ],
   )
 
-  first_update = build_transcription_update(state)
+  first_runs = _overlay_runs(state)
 
   state.open_command_start_s = 0.5
-  second_update = build_transcription_update(state)
+  second_runs = _overlay_runs(state)
 
-  assert first_update is not None
-  assert first_update.runs == [
+  assert first_runs == [
     TextRun(text="alpha", is_command=False, is_complete=True),
     TextRun(text="draft", is_command=False, is_complete=False),
   ]
-  assert second_update is not None
-  assert second_update.runs == [
+  assert second_runs == [
     TextRun(text="alpha", is_command=True, is_complete=True),
     TextRun(text="draft", is_command=True, is_complete=False),
   ]
 
 
-def test_serialize_text_runs_wraps_command_text_and_preserves_punctuation() -> None:
+def test_serialize_runs_for_rewrite_wraps_command_text_and_preserves_punctuation() -> None:
   assert (
-    serialize_text_runs(
+    serialize_runs_for_rewrite(
       [
         TextRun(text="Hello,", is_command=False, is_complete=True),
         TextRun(text="scratch", is_command=True, is_complete=True),
@@ -430,4 +427,17 @@ def test_serialize_text_runs_wraps_command_text_and_preserves_punctuation() -> N
       ]
     )
     == "Hello, <instruction>scratch that.</instruction> Bye."
+  )
+
+
+def test_serialize_runs_without_commands_drops_command_runs() -> None:
+  assert (
+    serialize_runs_without_commands(
+      [
+        TextRun(text="Hello,", is_command=False, is_complete=True),
+        TextRun(text="scratch that.", is_command=True, is_complete=True),
+        TextRun(text="Bye.", is_command=False, is_complete=True),
+      ]
+    )
+    == "Hello, Bye."
   )

--- a/packages/active-listener/tests/test_text_shaping.py
+++ b/packages/active-listener/tests/test_text_shaping.py
@@ -1,0 +1,69 @@
+"""Unit tests for deterministic transcript text shaping."""
+
+from __future__ import annotations
+
+from active_listener.recording.reducer import TextRun
+from active_listener.recording.text_shaping import shape_runs
+
+
+def test_shape_runs_applies_replacement_per_run_preserving_flags() -> None:
+  shaped = shape_runs(
+    [TextRun(text="hillary", is_command=True, is_complete=False)],
+    {},
+  )
+
+  assert [(run.text, run.is_command, run.is_complete) for run in shaped] == [
+    ("hilary", True, False)
+  ]
+
+
+def test_shape_runs_fuses_spoken_symbols() -> None:
+  shaped = shape_runs(
+    [TextRun(text="release hashtag 42", is_command=False, is_complete=True)],
+    {},
+  )
+
+  assert [run.text for run in shaped] == ["release#42"]
+
+
+def test_shape_runs_removes_unescaped_thank_you() -> None:
+  shaped = shape_runs(
+    [TextRun(text="hello thank you world", is_command=False, is_complete=True)],
+    {},
+  )
+
+  assert [run.text for run in shaped] == ["hello world"]
+
+
+def test_shape_runs_keeps_escaped_thank_you() -> None:
+  shaped = shape_runs(
+    [TextRun(text="escape thank you", is_command=False, is_complete=True)],
+    {},
+  )
+
+  assert [run.text for run in shaped] == ["thank you"]
+
+
+def test_shape_runs_applies_passed_corrections() -> None:
+  shaped = shape_runs(
+    [TextRun(text="foo", is_command=False, is_complete=True)],
+    {"foo": "bar"},
+  )
+
+  assert [run.text for run in shaped] == ["bar"]
+
+
+def test_shape_runs_drops_run_emptied_by_thank_you_and_preserves_flags() -> None:
+  shaped = shape_runs(
+    [
+      TextRun(text="thank you", is_command=False, is_complete=True),
+      TextRun(text="scratch that", is_command=True, is_complete=False),
+      TextRun(text="real text", is_command=False, is_complete=True),
+    ],
+    {},
+  )
+
+  assert [(run.text, run.is_command, run.is_complete) for run in shaped] == [
+    ("scratch that", True, False),
+    ("real text", False, True),
+  ]


### PR DESCRIPTION
Move the deterministic transforms (replacements, thank-you removal, symbol fusion, stored  corrections) out of the finalizer into a reusable text-shaping step that runs on every transcription window. The GNOME overlay and the LLM now consume the same shaped content by construction: what the user sees while speaking is exactly what the rewrite receives.

Vocabulary: "instruction markers" are the literal <instruction> tags, which exist only in the LLM-input serialization; a "command run" is a run dictated to the LLM (e.g. "scratch that"). The old name strip_instruction_tags fatally conflated two distinct operations:
- overlay: a command run's content is shown (purple), markers never are;
- LLM-off emit: the whole command run is dropped, content and all.

Fixes two latent bugs:
- Thank-you removal is now unconditional and lives in shaping. Whisper hallucinates "thank you" at silence boundaries; it is a model artifact, always removed before display and the LLM. The prior code only *asked* the LLM to remove it (unreliable, invisible in the live preview).
  "escape thank you" remains the deliberate opt-out. 
- When the LLM is off, command runs are dropped, not pasted. A command is an instruction with no consumer; the prior code stripped only the markers and left the literal content ("scratch that") in the output.

Marker-wrapping and command-dropping belong at the LLM boundary, so the
shaping pipeline never needs to know the LLM exists.